### PR TITLE
Don't stop notifications when app is backgrounded

### DIFF
--- a/src/ios/CDVConnection.m
+++ b/src/ios/CDVConnection.m
@@ -147,10 +147,10 @@
                                                  name:kReachabilityChangedNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(updateConnectionType:)
                                                  name:CTRadioAccessTechnologyDidChangeNotification object:nil];
-    if (UIApplicationDidEnterBackgroundNotification && UIApplicationWillEnterForegroundNotification) {
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onPause) name:UIApplicationDidEnterBackgroundNotification object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onResume) name:UIApplicationWillEnterForegroundNotification object:nil];
-    }
+    // if (UIApplicationDidEnterBackgroundNotification && UIApplicationWillEnterForegroundNotification) {
+    //     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onPause) name:UIApplicationDidEnterBackgroundNotification object:nil];
+    //     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onResume) name:UIApplicationWillEnterForegroundNotification object:nil];
+    // }
 }
 
 @end


### PR DESCRIPTION
Notifications (offline / online events) are currently paused when the app is backgrounded.

We still want to receive these notifications.